### PR TITLE
Add AWS_ENDPOINT_URL_S3 in addition to S3_ENDPOINT_URL

### DIFF
--- a/functions/master/open_archive/1.2.0/src/open_archive.py
+++ b/functions/master/open_archive/1.2.0/src/open_archive.py
@@ -120,8 +120,13 @@ def _extract_zip_file(archive_url, target_path: str = None, subdir: str = "conte
 
 def _init_boto3_client():
     import boto3
-    if os.environ.get('S3_ENDPOINT_URL'):
-        client = boto3.client('s3', endpoint_url=os.environ.get('S3_ENDPOINT_URL'))
+
+    # Backward compatibility: Support both S3_ENDPOINT_URL (deprecated) and AWS_ENDPOINT_URL_S3
+    # TODO: Remove this in 1.12.0
+    endpoint_url = os.environ.get('AWS_ENDPOINT_URL_S3') or os.environ.get('S3_ENDPOINT_URL')
+
+    if endpoint_url:
+        client = boto3.client('s3', endpoint_url=endpoint_url)
     else:
         client = boto3.client('s3')
     return client

--- a/functions/master/open_archive/1.2.0/static/open_archive.html
+++ b/functions/master/open_archive/1.2.0/static/open_archive.html
@@ -265,8 +265,13 @@ document.write(`
 
 <span class="k">def</span><span class="w"> </span><span class="nf">_init_boto3_client</span><span class="p">():</span>
     <span class="kn">import</span><span class="w"> </span><span class="nn">boto3</span>
-    <span class="k">if</span> <span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">'S3_ENDPOINT_URL'</span><span class="p">):</span>
-        <span class="n">client</span> <span class="o">=</span> <span class="n">boto3</span><span class="o">.</span><span class="n">client</span><span class="p">(</span><span class="s1">'s3'</span><span class="p">,</span> <span class="n">endpoint_url</span><span class="o">=</span><span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">'S3_ENDPOINT_URL'</span><span class="p">))</span>
+
+    <span class="c1"># Backward compatibility: Support both S3_ENDPOINT_URL (deprecated) and AWS_ENDPOINT_URL_S3</span>
+    <span class="c1"># TODO: Remove this in 1.12.0</span>
+    <span class="n">endpoint_url</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">'AWS_ENDPOINT_URL_S3'</span><span class="p">)</span> <span class="ow">or</span> <span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">'S3_ENDPOINT_URL'</span><span class="p">)</span>
+
+    <span class="k">if</span> <span class="n">endpoint_url</span><span class="p">:</span>
+        <span class="n">client</span> <span class="o">=</span> <span class="n">boto3</span><span class="o">.</span><span class="n">client</span><span class="p">(</span><span class="s1">'s3'</span><span class="p">,</span> <span class="n">endpoint_url</span><span class="o">=</span><span class="n">endpoint_url</span><span class="p">)</span>
     <span class="k">else</span><span class="p">:</span>
         <span class="n">client</span> <span class="o">=</span> <span class="n">boto3</span><span class="o">.</span><span class="n">client</span><span class="p">(</span><span class="s1">'s3'</span><span class="p">)</span>
     <span class="k">return</span> <span class="n">client</span>

--- a/functions/master/open_archive/1.2.0/static/source.html
+++ b/functions/master/open_archive/1.2.0/static/source.html
@@ -150,8 +150,13 @@ def _extract_zip_file(archive_url, target_path: str = None, subdir: str = "conte
 
 def _init_boto3_client():
     import boto3
-    if os.environ.get('S3_ENDPOINT_URL'):
-        client = boto3.client('s3', endpoint_url=os.environ.get('S3_ENDPOINT_URL'))
+
+    # Backward compatibility: Support both S3_ENDPOINT_URL (deprecated) and AWS_ENDPOINT_URL_S3
+    # TODO: Remove this in 1.12.0
+    endpoint_url = os.environ.get('AWS_ENDPOINT_URL_S3') or os.environ.get('S3_ENDPOINT_URL')
+
+    if endpoint_url:
+        client = boto3.client('s3', endpoint_url=endpoint_url)
     else:
         client = boto3.client('s3')
     return client

--- a/functions/master/open_archive/latest/src/open_archive.py
+++ b/functions/master/open_archive/latest/src/open_archive.py
@@ -120,8 +120,13 @@ def _extract_zip_file(archive_url, target_path: str = None, subdir: str = "conte
 
 def _init_boto3_client():
     import boto3
-    if os.environ.get('S3_ENDPOINT_URL'):
-        client = boto3.client('s3', endpoint_url=os.environ.get('S3_ENDPOINT_URL'))
+
+    # Backward compatibility: Support both S3_ENDPOINT_URL (deprecated) and AWS_ENDPOINT_URL_S3
+    # TODO: Remove this in 1.12.0
+    endpoint_url = os.environ.get('AWS_ENDPOINT_URL_S3') or os.environ.get('S3_ENDPOINT_URL')
+
+    if endpoint_url:
+        client = boto3.client('s3', endpoint_url=endpoint_url)
     else:
         client = boto3.client('s3')
     return client

--- a/functions/master/open_archive/latest/static/open_archive.html
+++ b/functions/master/open_archive/latest/static/open_archive.html
@@ -265,8 +265,13 @@ document.write(`
 
 <span class="k">def</span><span class="w"> </span><span class="nf">_init_boto3_client</span><span class="p">():</span>
     <span class="kn">import</span><span class="w"> </span><span class="nn">boto3</span>
-    <span class="k">if</span> <span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">'S3_ENDPOINT_URL'</span><span class="p">):</span>
-        <span class="n">client</span> <span class="o">=</span> <span class="n">boto3</span><span class="o">.</span><span class="n">client</span><span class="p">(</span><span class="s1">'s3'</span><span class="p">,</span> <span class="n">endpoint_url</span><span class="o">=</span><span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">'S3_ENDPOINT_URL'</span><span class="p">))</span>
+
+    <span class="c1"># Backward compatibility: Support both S3_ENDPOINT_URL (deprecated) and AWS_ENDPOINT_URL_S3</span>
+    <span class="c1"># TODO: Remove this in 1.12.0</span>
+    <span class="n">endpoint_url</span> <span class="o">=</span> <span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">'AWS_ENDPOINT_URL_S3'</span><span class="p">)</span> <span class="ow">or</span> <span class="n">os</span><span class="o">.</span><span class="n">environ</span><span class="o">.</span><span class="n">get</span><span class="p">(</span><span class="s1">'S3_ENDPOINT_URL'</span><span class="p">)</span>
+
+    <span class="k">if</span> <span class="n">endpoint_url</span><span class="p">:</span>
+        <span class="n">client</span> <span class="o">=</span> <span class="n">boto3</span><span class="o">.</span><span class="n">client</span><span class="p">(</span><span class="s1">'s3'</span><span class="p">,</span> <span class="n">endpoint_url</span><span class="o">=</span><span class="n">endpoint_url</span><span class="p">)</span>
     <span class="k">else</span><span class="p">:</span>
         <span class="n">client</span> <span class="o">=</span> <span class="n">boto3</span><span class="o">.</span><span class="n">client</span><span class="p">(</span><span class="s1">'s3'</span><span class="p">)</span>
     <span class="k">return</span> <span class="n">client</span>

--- a/functions/master/open_archive/latest/static/source.html
+++ b/functions/master/open_archive/latest/static/source.html
@@ -150,8 +150,13 @@ def _extract_zip_file(archive_url, target_path: str = None, subdir: str = "conte
 
 def _init_boto3_client():
     import boto3
-    if os.environ.get('S3_ENDPOINT_URL'):
-        client = boto3.client('s3', endpoint_url=os.environ.get('S3_ENDPOINT_URL'))
+
+    # Backward compatibility: Support both S3_ENDPOINT_URL (deprecated) and AWS_ENDPOINT_URL_S3
+    # TODO: Remove this in 1.12.0
+    endpoint_url = os.environ.get('AWS_ENDPOINT_URL_S3') or os.environ.get('S3_ENDPOINT_URL')
+
+    if endpoint_url:
+        client = boto3.client('s3', endpoint_url=endpoint_url)
     else:
         client = boto3.client('s3')
     return client


### PR DESCRIPTION
As part of deprecation of the S3_ENDPOINT_URL in favour of AWS_ENDPOINT_URL_S3 , add AWS_ENDPOINT_URL_S3 to the environment keys
ML-11061